### PR TITLE
Add text-align: center to content header

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -111,6 +111,7 @@ button {
   font-size: 36x;
   color: #1f2937;
   font-weight: 900;
+  text-align: center;
 }
 
 .card-container {


### PR DESCRIPTION
Now the header text in the content section is centered on smaller screens.
Closes #1 